### PR TITLE
Consolidate code, support long stack traces in fs module.

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -13,13 +13,15 @@ test('normal throw', function() {
     });
 });
 
-test('errors from other modules', function(done) {
+test('errors inside fs', function(done) {
 
     fs.readFile('not_there.txt', 'utf8', function (err, text) {
         assert(err instanceof Error);
-        assert.equal(err.stack, 'Error: ENOENT, open \'not_there.txt\'');
+        assert.ok(err.stack.indexOf('Error: ENOENT, open \'not_there.txt\'') === 0);
+        assert.equal(err.stack.split("\n").length, 11);
         done();
     });
+
 });
 
 test('function inside timeout', function(done) {


### PR DESCRIPTION
Two things:

1) There's now a `wrap_library` function which will wrap all the functions, and any callbacks to those functions, in a module.
2) Wrapping `fs` by default - is there any reason /not/ to wrap `fs` and other core libs by default?
